### PR TITLE
Improve cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,20 +60,13 @@ runs:
         aws-region: ${{ inputs.aws-region }}
 
     - uses: aws-actions/amazon-ecr-login@v1
-
-    - uses: actions/cache@v2.1.4
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-buildx-
-
-    - uses: docker/build-push-action@v2
+    - uses: docker/build-push-action@v4
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.path-to-dockerfile }}
         push: true
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |


### PR DESCRIPTION
The old cache configuration did not work entirely. It was bigger 5GB and the limit is 5GB. GHA is better.  Even more, the key included github.sha, as a result with each commit to PR the cache was invalidated. This improvement decreases docker job execution time from around 20 minutes to 2 minutes on modification of files from .dockerignore file